### PR TITLE
Initialize Hardhat project scaffolding

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,19 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.20",
+  networks: {
+    bscTestnet: {
+      url: "https://data-seed-prebsc-1-s1.binance.org:8545",
+      chainId: 97,
+      accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+    },
+    // solanaBridge: {
+    //   // Placeholder for Solana bridge configuration
+    //   // url: "https://api.testnet.solana.com"
+    // }
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "backedtoken_v3",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "compile": "hardhat compile",
+    "test": "hardhat test",
+    "deploy": "hardhat run scripts/deploy.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "hardhat": "^2.22.5",
+    "@nomicfoundation/hardhat-toolbox": "^4.0.0",
+    "typescript": "^5.5.0",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,0 +1,11 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  // Placeholder deploy script
+  console.log("Deploy script placeholder");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "types": ["node", "hardhat"]
+  },
+  "include": ["scripts", "test"],
+  "files": ["hardhat.config.ts"]
+}


### PR DESCRIPTION
## Summary
- Add Hardhat TypeScript config with BSC testnet settings and Solana bridge placeholders
- Add package.json scripts for compile, test, and deploy
- Include placeholder deploy script and TypeScript config

## Testing
- `npm run compile` (fails: hardhat: not found)
- `npm test` (fails: hardhat: not found)
- `npm run deploy` (fails: hardhat: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad891c00cc83248728628d1c1cd232