### PR TITLE
Integrate OracleStub price oracle

### DIFF
--- a/contracts/BackedToken.sol
+++ b/contracts/BackedToken.sol
@@ -5,23 +5,20 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
-interface IPriceOracle {
-    /// @notice Returns the price of one token in terms of the stablecoin.
-    /// @dev The price is scaled by 1e18.
-    function price() external view returns (uint256);
-}
+import "./OracleStub.sol";
 
 interface IBridge {
-    /// @notice Enqueue a redemption request for `account` of `amount` tokens.
+    /// @notice Enqueue a redemption request for `account` of `amount` stablecoin.
     function enqueueRedemption(address account, uint256 amount) external;
 }
 
 contract BackedToken is ERC20, Ownable {
     using SafeERC20 for IERC20;
 
+    uint256 private constant PRICE_PRECISION = 1e18;
+
     IERC20 public immutable stablecoin;
-    IPriceOracle public oracle;
+    OracleStub public oracle;
     IBridge public bridge;
 
     constructor(
@@ -30,7 +27,7 @@ contract BackedToken is ERC20, Ownable {
         address bridgeAddress
     ) ERC20("Backed Token", "BKT") Ownable(msg.sender) {
         stablecoin = IERC20(stablecoinAddress);
-        oracle = IPriceOracle(oracleAddress);
+        oracle = OracleStub(oracleAddress);
         bridge = IBridge(bridgeAddress);
     }
 
@@ -39,10 +36,10 @@ contract BackedToken is ERC20, Ownable {
     function buy(uint256 stableAmount) external {
         require(stableAmount > 0, "amount zero");
 
-        uint256 price = oracle.price();
+        uint256 price = oracle.getPrice();
         require(price > 0, "invalid price");
 
-        uint256 tokenAmount = (stableAmount * 1e18) / price;
+        uint256 tokenAmount = (stableAmount * PRICE_PRECISION) / price;
 
         stablecoin.safeTransferFrom(msg.sender, address(bridge), stableAmount);
         _mint(msg.sender, tokenAmount);
@@ -53,8 +50,13 @@ contract BackedToken is ERC20, Ownable {
     function redeem(uint256 tokenAmount) external {
         require(tokenAmount > 0, "amount zero");
 
+        uint256 price = oracle.getPrice();
+        require(price > 0, "invalid price");
+
+        uint256 stableAmount = (tokenAmount * price) / PRICE_PRECISION;
+
         _burn(msg.sender, tokenAmount);
-        bridge.enqueueRedemption(msg.sender, tokenAmount);
+        bridge.enqueueRedemption(msg.sender, stableAmount);
     }
 }
 

--- a/contracts/OracleStub.sol
+++ b/contracts/OracleStub.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract OracleStub is Ownable {
+    uint256 private price;
+
+    constructor(uint256 initialPrice) Ownable(msg.sender) {
+        price = initialPrice;
+    }
+
+    function setPrice(uint256 newPrice) external onlyOwner {
+        price = newPrice;
+    }
+
+    function getPrice() external view returns (uint256) {
+        return price;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add owner-controlled `OracleStub` price oracle
- use `OracleStub` in `BackedToken` for pricing when buying and redeeming tokens
- centralize pricing precision with `PRICE_PRECISION` constant

## Testing
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden - @openzeppelin/contracts-5.4.0.tgz)*
- `npm test` *(fails: library @openzeppelin/contracts not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9bbbf0588324bba3c642560505f7