### PR TITLE
Add liquidity buffer and bridge-aware buy/redeem logic

### DIFF
--- a/test/BackedToken.ts
+++ b/test/BackedToken.ts
@@ -2,6 +2,8 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 
+const INITIAL_PRICE = ethers.parseUnits("2", 18);
+
 // Helper to deploy contracts for each test
 async function deployFixture() {
   const [owner, user] = await ethers.getSigners();
@@ -11,8 +13,7 @@ async function deployFixture() {
   await stablecoin.waitForDeployment();
 
   const Oracle = await ethers.getContractFactory("OracleStub");
-  const initialPrice = ethers.parseUnits("1", 18);
-  const oracle = await Oracle.deploy(initialPrice);
+  const oracle = await Oracle.deploy(INITIAL_PRICE);
   await oracle.waitForDeployment();
 
   const Bridge = await ethers.getContractFactory("BridgeStub");
@@ -23,9 +24,10 @@ async function deployFixture() {
   const backedToken = await Backed.deploy(stablecoin.target, oracle.target, bridge.target);
   await backedToken.waitForDeployment();
 
-  // Mint stablecoins to user for testing
-  const supply = ethers.parseUnits("1000", 18);
+  // Mint stablecoins to user and owner for testing
+  const supply = ethers.parseUnits("2000", 18);
   await stablecoin.mint(user.address, supply);
+  await stablecoin.mint(owner.address, supply);
 
   return { owner, user, stablecoin, oracle, bridge, backedToken };
 }
@@ -33,15 +35,17 @@ async function deployFixture() {
 describe("BackedToken", function () {
   it("retrieves price from oracle", async function () {
     const { oracle, owner } = await loadFixture(deployFixture);
-    const newPrice = ethers.parseUnits("2", 18);
+    const newPrice = ethers.parseUnits("3", 18);
     await oracle.connect(owner).setPrice(newPrice);
     expect(await oracle.getPrice()).to.equal(newPrice);
   });
 
-  it("allows purchasing tokens", async function () {
-    const { user, stablecoin, oracle, bridge, backedToken } = await loadFixture(deployFixture);
+  it("allows purchasing tokens while keeping buffer", async function () {
+    const { user, owner, stablecoin, oracle, bridge, backedToken } = await loadFixture(deployFixture);
     const buyAmount = ethers.parseUnits("100", 18);
+    const threshold = ethers.parseUnits("50", 18);
 
+    await backedToken.connect(owner).setBufferThreshold(threshold);
     await stablecoin.connect(user).approve(backedToken.target, buyAmount);
 
     const price = await oracle.getPrice();
@@ -49,35 +53,131 @@ describe("BackedToken", function () {
 
     await expect(backedToken.connect(user).buy(buyAmount))
       .to.emit(bridge, "StableSent")
-      .withArgs(stablecoin.target, backedToken.target, buyAmount);
+      .withArgs(stablecoin.target, backedToken.target, buyAmount - threshold);
 
     expect(await backedToken.balanceOf(user.address)).to.equal(expectedTokens);
-    expect(await stablecoin.balanceOf(bridge.target)).to.equal(buyAmount);
-
-    // simulate the stablecoin being received on the other chain
-    await bridge.receiveStable(stablecoin.target, buyAmount);
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(threshold);
   });
 
-  it("allows redeeming tokens", async function () {
-    const { user, stablecoin, oracle, bridge, backedToken } = await loadFixture(deployFixture);
-    const amount = ethers.parseUnits("50", 18);
+  it("only bridges when amount exceeds minimum", async function () {
+    const { user, owner, stablecoin, bridge, backedToken } = await loadFixture(deployFixture);
+    const threshold = ethers.parseUnits("40", 18);
+    const minBridge = ethers.parseUnits("30", 18);
+    const firstBuy = ethers.parseUnits("60", 18);
+    const secondBuy = ethers.parseUnits("20", 18);
 
-    await stablecoin.connect(user).approve(backedToken.target, amount);
-    await backedToken.connect(user).buy(amount);
+    await backedToken.connect(owner).setBufferThreshold(threshold);
+    await backedToken.connect(owner).setMinBridgeAmount(minBridge);
+
+    await stablecoin.connect(user).approve(backedToken.target, firstBuy + secondBuy);
+
+    await expect(backedToken.connect(user).buy(firstBuy)).to.not.emit(bridge, "StableSent");
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(firstBuy);
+
+    const expectedBridge = firstBuy + secondBuy - threshold;
+    await expect(backedToken.connect(user).buy(secondBuy))
+      .to.emit(bridge, "StableSent")
+      .withArgs(stablecoin.target, backedToken.target, expectedBridge);
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(threshold);
+  });
+
+  it(
+    "allows purchasing token less than minBridgeAmount while keeping buffer (Empty Buffer)",
+    async function () {
+      const { user, owner, stablecoin, oracle, backedToken } = await loadFixture(
+        deployFixture
+      );
+      const buyAmount = ethers.parseUnits("80", 18);
+      const threshold = ethers.parseUnits("50", 18);
+      const minBridge = ethers.parseUnits("50", 18);
+
+      await backedToken.connect(owner).setBufferThreshold(threshold);
+      await backedToken.connect(owner).setMinBridgeAmount(minBridge);
+      await stablecoin.connect(user).approve(backedToken.target, buyAmount);
+
+      const price = await oracle.getPrice();
+      const expectedTokens = (buyAmount * BigInt(1e18)) / price;
+
+      await backedToken.connect(user).buy(buyAmount);
+
+      const stableLiquidity = await stablecoin.balanceOf(backedToken.target);
+      const userBalance = await backedToken.balanceOf(user.address);
+
+      expect(userBalance).to.equal(expectedTokens);
+      expect(stableLiquidity).to.equal(buyAmount);
+    }
+  );
+
+  it(
+    "allows purchasing token less than minBridgeAmount while keeping buffer (Full Buffer)",
+    async function () {
+      const { user, owner, stablecoin, oracle, backedToken } = await loadFixture(
+        deployFixture
+      );
+      const buyAmount = ethers.parseUnits("40", 18);
+      const threshold = ethers.parseUnits("50", 18);
+      const minBridge = ethers.parseUnits("50", 18);
+
+      await backedToken.connect(owner).setBufferThreshold(threshold);
+      await backedToken.connect(owner).setMinBridgeAmount(minBridge);
+      await stablecoin.connect(owner).approve(backedToken.target, threshold);
+      await backedToken.connect(owner).depositBuffer(threshold);
+      await stablecoin.connect(user).approve(backedToken.target, buyAmount);
+
+      const price = await oracle.getPrice();
+      const expectedTokens = (buyAmount * BigInt(1e18)) / price;
+
+      await backedToken.connect(user).buy(buyAmount);
+
+      const stableLiquidity = await stablecoin.balanceOf(backedToken.target);
+      const userBalance = await backedToken.balanceOf(user.address);
+
+      expect(userBalance).to.equal(expectedTokens);
+      expect(stableLiquidity).to.equal(threshold + buyAmount);
+    }
+  );
+
+  it("allows owner to manage buffer", async function () {
+    const { owner, stablecoin, backedToken } = await loadFixture(deployFixture);
+    const depositAmount = ethers.parseUnits("20", 18);
+    const withdrawAmount = ethers.parseUnits("5", 18);
+    await stablecoin.connect(owner).approve(backedToken.target, depositAmount);
+
+    await backedToken.connect(owner).depositBuffer(depositAmount);
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(depositAmount);
+
+    await backedToken.connect(owner).withdrawBuffer(withdrawAmount);
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(depositAmount - withdrawAmount);
+  });
+
+  it("uses buffer on redeem before bridging", async function () {
+    const { user, owner, stablecoin, oracle, bridge, backedToken } = await loadFixture(deployFixture);
+    const buyAmount = ethers.parseUnits("50", 18);
+    const bufferDeposit = ethers.parseUnits("20", 18);
+    const redeemTokens = ethers.parseUnits("25", 18);
+
+    // Buy tokens (all funds go through bridge since threshold is 0)
+    await stablecoin.connect(user).approve(backedToken.target, buyAmount);
+    await backedToken.connect(user).buy(buyAmount);
+
+    // Owner deposits liquidity for redemptions
+    await stablecoin.connect(owner).approve(backedToken.target, bufferDeposit);
+    await backedToken.connect(owner).depositBuffer(bufferDeposit);
 
     const price = await oracle.getPrice();
+    const expectedBridge = (redeemTokens * price) / BigInt(1e18) - bufferDeposit;
     const encoded = ethers.AbiCoder.defaultAbiCoder().encode([
       "address",
       "uint256",
-    ], [user.address, (amount * price) / BigInt(1e18)]);
+    ], [user.address, expectedBridge]);
 
-    await expect(backedToken.connect(user).redeem(amount))
+    await expect(backedToken.connect(user).redeem(redeemTokens))
       .to.emit(bridge, "MessageSent")
       .withArgs(encoded);
 
-    expect(await backedToken.balanceOf(user.address)).to.equal(0n);
-
-    // simulate stablecoin release through the bridge
-    await bridge.receiveStable(stablecoin.target, amount);
+    expect(await stablecoin.balanceOf(backedToken.target)).to.equal(0n);
+    expect(await stablecoin.balanceOf(user.address)).to.equal(
+      ethers.parseUnits("2000", 18) - buyAmount + bufferDeposit
+    );
   });
 });


### PR DESCRIPTION
## Summary
- track in-contract stablecoin via balance and owner deposit/withdraw functions
- bridge excess stable only when balance surpasses `bufferThreshold + minBridgeAmount`
- satisfy redemptions from contract balance before sending bridge messages
- define initial oracle price constant and add coverage for min-bridge scenarios

## Testing
- `npm test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68aecea40b748324bd8f1e27df8574a1