### PR TITLE
Restrict redemption processing to internal function

### DIFF
--- a/contracts/BackedToken.sol
+++ b/contracts/BackedToken.sol
@@ -62,6 +62,7 @@ contract BackedToken is ERC20, Ownable {
     function depositBuffer(uint256 amount) external onlyOwner {
         require(amount > 0, "amount zero");
         stablecoin.safeTransferFrom(msg.sender, address(this), amount);
+        _processRedemptions(address(0), 0);
     }
 
     /// @notice Withdraw stablecoins from the local liquidity buffer.
@@ -79,7 +80,7 @@ contract BackedToken is ERC20, Ownable {
     /// available buffer liquidity.
     /// @param redeemer Address requesting redemption (zero to process queue only).
     /// @param amount Amount requested for redemption.
-    function processRedemptions(address redeemer, uint256 amount) public {
+    function _processRedemptions(address redeemer, uint256 amount) internal {
         RedemptionQueue.Redeem[] memory payouts = redemptionQueue.process(
             redeemer,
             amount,
@@ -114,7 +115,7 @@ contract BackedToken is ERC20, Ownable {
         stablecoin.safeTransferFrom(msg.sender, address(this), stableAmount);
 
         // Settle queued redemptions and forward any excess liquidity.
-        processRedemptions(address(0), 0);
+        _processRedemptions(address(0), 0);
         forwardExcessToBridge();
         _mint(msg.sender, tokenAmount);
     }
@@ -131,7 +132,7 @@ contract BackedToken is ERC20, Ownable {
 
         _burn(msg.sender, tokenAmount);
 
-        processRedemptions(msg.sender, stableAmount);
+        _processRedemptions(msg.sender, stableAmount);
     }
 }
 

--- a/test/BackedToken.ts
+++ b/test/BackedToken.ts
@@ -207,10 +207,6 @@ describe("BackedToken", function () {
     await stablecoin.connect(owner).approve(backedToken.target, expectedPayout);
     await backedToken.connect(owner).depositBuffer(expectedPayout);
 
-    expect(await backedToken.redemptionQueueLength()).to.equal(1n);
-
-    await backedToken.processRedemptions(ethers.ZeroAddress, 0);
-
     expect(await backedToken.redemptionQueueLength()).to.equal(0n);
     expect(await stablecoin.balanceOf(user.address)).to.equal(
       ethers.parseUnits("2000", 18) - buyAmount + expectedPayout


### PR DESCRIPTION
## Summary
- Make redemption processing internal by converting `processRedemptions` into `_processRedemptions`
- Trigger redemption processing from buffer deposits and adjust buy/redeem flows
- Update tests for internal-only redemption processing

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68b06fb58ad88324a54d2a5804221fb7