### PR TITLE
Ensure redemption queue honors unpaid requests

### DIFF
--- a/contracts/RedemptionQueue.sol
+++ b/contracts/RedemptionQueue.sol
@@ -46,10 +46,12 @@ library RedemptionQueue {
         }
 
         bool considerNew = redeemer != address(0) && amount > 0;
+        bool allItemsAreProcessed = q.tail == idx;
         bool newPayable =
             considerNew &&
             amount <= remaining &&
-            processed < maxToProcess;
+            processed < maxToProcess &&
+            allItemsAreProcessed;
 
         uint256 payoutCount = processed + (newPayable ? 1 : 0);
         payables = new Redeem[](payoutCount);


### PR DESCRIPTION
## Summary
- Require all prior requests processed before treating a new redemption as payable
- Clarify logic with `allItemsAreProcessed` flag

## Testing
- ⚠️ `npm test test/BackedToken.ts` *(Hardhat failed to download solc compiler: HH502)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd1a741883248d4c09420d5064bd