### PR TITLE
Use forceApprove when forwarding stablecoin to bridge

### DIFF
--- a/contracts/BackedToken.sol
+++ b/contracts/BackedToken.sol
@@ -115,8 +115,7 @@ contract BackedToken is ERC20, Ownable {
         uint256 balance = stablecoin.balanceOf(address(this));
         if (balance > bufferThreshold + minBridgeAmount) {
             uint256 toBridge = balance - bufferThreshold;
-            stablecoin.safeApprove(address(bridge), 0);
-            stablecoin.safeApprove(address(bridge), toBridge);
+            stablecoin.forceApprove(address(bridge), toBridge);
             bridge.sendStable(address(stablecoin), toBridge);
         }
     }


### PR DESCRIPTION
## Summary
- replace removed `safeApprove` calls with `forceApprove` in `forwardExcessToBridge`

## Testing
- `npm run compile` *(fails: Couldn't download compiler version list; Proxy response (403))*
- `npm test` *(fails: Couldn't download compiler version list; Proxy response (403))*

------
https://chatgpt.com/codex/tasks/task_e_68b2d113fcb88324a90e8bb59343af48